### PR TITLE
Corrected run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a `simple` docker image for running the github pages stuff locally (jeky
 Go to your app root and switch to the ```gh-pages``` branch. Afterwards run:
  
 ```
-docker run --rm -ti -v $(pwd):/app -p 4000:4000 gekkie/gh-pages
+docker run --rm -ti -v $(pwd):/app -p 4000:4000 gekkie/docker-gh-pages
 ```
 
 You can now live edit your files locally and watch [localhost:4000](http://127.0.0.1.xip.io:4000)


### PR DESCRIPTION
The run command in your readme doesn't quite work; corrected with the correct docker image tag
